### PR TITLE
Add main field to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,5 +3,8 @@
   "version": "2.0.1",
   "homepage": "https://github.com/sathyapulse/angular-recorder",
   "description": "Pure Angular js recorder which will support both Flash and HTML5",
-  "license": "MIT"
+  "license": "MIT",
+  "main": [
+    "record-builder.js"
+  ]
 }


### PR DESCRIPTION
The main field is required to make the project work with `wiredep`.
